### PR TITLE
fix quiz-result-complete.html and quiz-extra.js

### DIFF
--- a/js/quiz-complete.js
+++ b/js/quiz-complete.js
@@ -27,7 +27,7 @@ function questionJudge(check) {
     if(index >= quizzes.length - 1) {
         localStorage.setItem("score", score);
         localStorage.setItem("quizCount", quizzes.length);
-        location.href="quiz-result-complete .html";
+        location.href="quiz-result-complete.html";
     }
 
     index++;

--- a/js/quiz-complete.js
+++ b/js/quiz-complete.js
@@ -1,4 +1,4 @@
-completevar quizzes = [
+var quizzes = [
     "テトリスを作ったのは日本人である",
     "１円玉の直径は2cmである",
     "塩はカロリー0である",

--- a/js/quiz-extra.js
+++ b/js/quiz-extra.js
@@ -31,5 +31,5 @@ function questionJudge(check) {
     }
 
     index++;
-    updateQuestion()
+    updateQuestion();
 }

--- a/js/quiz-extra.js
+++ b/js/quiz-extra.js
@@ -26,6 +26,7 @@ function questionJudge(check) {
 
     if(index >= quizzes.length - 1) {
         localStorage.setItem("score", score);
+        localStorage.setItem("quizCount", quizzes.length);
         location.href="quiz-result-extra.html";
     }
 

--- a/js/quiz-result-complete.js
+++ b/js/quiz-result-complete.js
@@ -1,4 +1,4 @@
 function result() {
-    var score  = localStorage.getItem("score");
+    var score = localStorage.getItem("score");
     document.getElementById("score").innerText = score;
 }

--- a/js/quiz-result-extra.js
+++ b/js/quiz-result-extra.js
@@ -5,5 +5,5 @@ function result() {
     var percentage = Math.round(score/quizCount * 100);
     document.getElementById("score").innerText = score;
     document.getElementById("missCount").innerText = missCount;
-    document.getElementById("percentage").innerText = percentage + "%"
+    document.getElementById("percentage").innerText = percentage + "%";
 }

--- a/quiz-result-complete.html
+++ b/quiz-result-complete.html
@@ -10,7 +10,7 @@
 
 </head>
 <body
-    onload="result()"
+    onload="result();"
 >
     <section>
         <h1>結果表示画面</h1>

--- a/quiz-result-extra.html
+++ b/quiz-result-extra.html
@@ -10,7 +10,7 @@
 
 </head>
 <body
-    onload="result()"
+    onload="result();"
 >
     <section>
         <h1>結果表示画面</h1>
@@ -33,7 +33,7 @@
     </section>
     <section>
         <a
-           href="quiz-question.html"
+           href="quiz-question-extra.html"
         >
             もう一度...!
         </a>


### PR DESCRIPTION
・quiz-result-complete.html及びextra.htmlにおいて
　　onload文中のセミコロンの追記

・quiz-extra.jsにおいて
　　questionJudge()内の
　　　　localStorage.setItem("quizCount", quizzes.length);
　　の追記（これ書かれてないのにextraの結果画面正常に動いていたのはなぜ、、、？僕の勉強不足、、、？）